### PR TITLE
Bugfix/CURT-278 - Updated to use MAC instead of serial number.

### DIFF
--- a/src/ids.portable.flic.button/Platforms/Android/NativeFlicButtonManager.cs
+++ b/src/ids.portable.flic.button/Platforms/Android/NativeFlicButtonManager.cs
@@ -5,6 +5,8 @@ using IO.Flic.Flic2libandroid;
 using IDS.Portable.Common;
 using System.Threading.Tasks;
 using System.Threading;
+using IDS.Core.IDS_CAN;
+using IDS.Portable.LogicalDevice;
 
 namespace IDS.Portable.Flic.Button.Platforms.Android
 {
@@ -38,7 +40,7 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
             return await tcs.TryWaitAsync(cancellationToken);
         }
 
-        public void SubscribeToButtonEvents(string serialNumber, Action<FlicButtonEventData> flicEvent)
+        public void SubscribeToButtonEvents(MAC mac, Action<FlicButtonEventData> flicEvent)
         {
             var manager = Flic2Manager.Instance;
 
@@ -46,14 +48,14 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
                 throw new FlicButtonManagerNullException();
 
             var buttons = manager.Buttons;
-            var button = buttons.FirstOrDefault(button => button.SerialNumber == serialNumber);
+            var button = buttons.FirstOrDefault(button => button.BdAddr.ToMAC() == mac);
             if (button is null)
-                throw new FlicButtonNullException($"No flic button found with the serial number: {serialNumber}");
+                throw new FlicButtonNullException($"No flic button found with the mac: {mac}");
 
             button.AddListener(new FlicButtonListenerCallback(flicEvent));
         }
 
-        public void ConnectButton(string serialNumber)
+        public void ConnectButton(MAC mac)
         {
             var manager = Flic2Manager.Instance;
 
@@ -61,14 +63,14 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
                 throw new FlicButtonManagerNullException();
 
             var buttons = manager.Buttons;
-            var button = buttons.FirstOrDefault(button => button.SerialNumber == serialNumber);
+            var button = buttons.FirstOrDefault(button => button.BdAddr.ToMAC() == mac);
             if (button is null)
-                throw new FlicButtonNullException($"No flic button found with the serial number: {serialNumber}");
+                throw new FlicButtonNullException($"No flic button found with the mac: {mac}");
 
             button.Connect();
         }
 
-        public void DisconnectOrAbortPendingConnection(string serialNumber)
+        public void DisconnectOrAbortPendingConnection(MAC mac)
         {
             var manager = Flic2Manager.Instance;
 
@@ -76,14 +78,14 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
                 throw new FlicButtonManagerNullException();
 
             var buttons = manager.Buttons;
-            var button = buttons.FirstOrDefault(button => button.SerialNumber == serialNumber);
+            var button = buttons.FirstOrDefault(button => button.BdAddr.ToMAC() == mac);
             if (button is null)
-                throw new FlicButtonNullException($"No flic button found with the serial number: {serialNumber}");
+                throw new FlicButtonNullException($"No flic button found with the mac: {mac}");
 
             button.DisconnectOrAbortPendingConnection();
         }
 
-        public Task<bool> UnpairButton(string serialNumber)
+        public Task<bool> UnpairButton(MAC mac)
         {
             var manager = Flic2Manager.Instance;
 
@@ -91,9 +93,9 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
                 throw new FlicButtonManagerNullException();
 
             var buttons = manager.Buttons;
-            var button = buttons.FirstOrDefault(button => button.SerialNumber == serialNumber);
+            var button = buttons.FirstOrDefault(button => button.BdAddr.ToMAC() == mac);
             if (button is null)
-                throw new FlicButtonNullException($"No flic button found with the serial number: {serialNumber}");
+                throw new FlicButtonNullException($"No flic button found with the mac: {mac}");
 
             manager.ForgetButton(button);
 

--- a/src/ids.portable.flic.button/Platforms/Shared/FlicButtonBleDeviceDriver.cs
+++ b/src/ids.portable.flic.button/Platforms/Shared/FlicButtonBleDeviceDriver.cs
@@ -109,12 +109,12 @@ namespace IDS.Portable.Flic.Button.Platforms.Shared
                 try
                 {
                     // Close any open connection
-                    FlicButtonManager.Instance.DisconnectOrAbortPendingConnection(SensorConnection.SerialNumber);
+                    FlicButtonManager.Instance.DisconnectOrAbortPendingConnection(SensorConnection.AccessoryMac);
 
-                    FlicButtonManager.Instance.SubscribeToButtonEvents(SensorConnection.SerialNumber, OnFlicButtonEventReceived);
+                    FlicButtonManager.Instance.SubscribeToButtonEvents(SensorConnection.AccessoryMac, OnFlicButtonEventReceived);
 
                     // Open Connection
-                    FlicButtonManager.Instance.ConnectButton(SensorConnection.SerialNumber);
+                    FlicButtonManager.Instance.ConnectButton(SensorConnection.AccessoryMac);
                 }
                 catch (Exception ex)
                 {
@@ -129,7 +129,7 @@ namespace IDS.Portable.Flic.Button.Platforms.Shared
             {
                 try
                 {
-                    FlicButtonManager.Instance.DisconnectOrAbortPendingConnection(SensorConnection.SerialNumber);
+                    FlicButtonManager.Instance.DisconnectOrAbortPendingConnection(SensorConnection.AccessoryMac);
                 }
                 catch (Exception e)
                 {

--- a/src/ids.portable.flic.button/Platforms/Shared/FlicButtonBleDeviceSource.cs
+++ b/src/ids.portable.flic.button/Platforms/Shared/FlicButtonBleDeviceSource.cs
@@ -136,6 +136,7 @@ namespace IDS.Portable.Flic.Button.Platforms.Shared
                     return false;
 
                 var flicButton = new FlicButtonBleDeviceDriver(this, sensorConnection);
+                flicButton.LogicalDevice?.AddDeviceSource(this);
 
                 var newRegistration = _registeredFlicButtons.TryAdd(bleDeviceId, flicButton);
                 if (newRegistration)

--- a/src/ids.portable.flic.button/Platforms/Shared/FlicButtonManager.cs
+++ b/src/ids.portable.flic.button/Platforms/Shared/FlicButtonManager.cs
@@ -1,4 +1,5 @@
-﻿using IDS.Portable.Common;
+﻿using IDS.Core.IDS_CAN;
+using IDS.Portable.Common;
 using IDS.Portable.Common.Utils;
 using IDS.Portable.LogicalDevice;
 using System;
@@ -58,22 +59,22 @@ namespace IDS.Portable.Flic.Button.Platforms.Shared
         /// </summary>
         /// <param name="serialNumber">The serial number of the device to subscribe to.</param>
         /// <param name="cancellationToken"></param>
-        public void SubscribeToButtonEvents(string serialNumber, Action<FlicButtonEventData> flicEvent) =>
-        _nativeFlicButtonManager.SubscribeToButtonEvents(serialNumber, flicEvent);
+        public void SubscribeToButtonEvents(MAC mac, Action<FlicButtonEventData> flicEvent) =>
+        _nativeFlicButtonManager.SubscribeToButtonEvents(mac, flicEvent);
 
         /// <summary>
         /// Attempts to connect to a flic button with the given serial number. Returns connection status via SubscribeToButtonEvents.
         /// </summary>
         /// <param name="serialNumber">The serial number of the device to connect to.</param>
-        public void ConnectButton(string serialNumber) =>
-            _nativeFlicButtonManager.ConnectButton(serialNumber);
+        public void ConnectButton(MAC mac) =>
+            _nativeFlicButtonManager.ConnectButton(mac);
 
         /// <summary>
         /// Disconnects or aborts a pending connection to a flic button with the given serial number.
         /// </summary>
         /// <param name="serialNumber">The serial number of the device to disconnect from.</param>
-        public void DisconnectOrAbortPendingConnection(string serialNumber) =>
-            _nativeFlicButtonManager.DisconnectOrAbortPendingConnection(serialNumber);
+        public void DisconnectOrAbortPendingConnection(MAC mac) =>
+            _nativeFlicButtonManager.DisconnectOrAbortPendingConnection(mac);
 
         /// <summary>
         /// Completely removes a button from the flic manager. It is important to call this before we finish removing the device
@@ -81,7 +82,7 @@ namespace IDS.Portable.Flic.Button.Platforms.Shared
         /// </summary>
         /// <param name="serialNumber">The serial number of the device to unpair from.</param>
         /// <returns>True if removing the button was successful.</returns>
-        public async Task<bool> UnpairButton(string serialNumber) =>
-            await _nativeFlicButtonManager.UnpairButton(serialNumber);
+        public async Task<bool> UnpairButton(MAC mac) =>
+            await _nativeFlicButtonManager.UnpairButton(mac);
     }
 }

--- a/src/ids.portable.flic.button/Platforms/Shared/IFlicButtonManager.cs
+++ b/src/ids.portable.flic.button/Platforms/Shared/IFlicButtonManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using System.Threading;
+using IDS.Core.IDS_CAN;
 
 namespace IDS.Portable.Flic.Button.Platforms.Shared
 {
@@ -54,9 +55,9 @@ namespace IDS.Portable.Flic.Button.Platforms.Shared
 
         Task Init();
         Task<FlicButtonDeviceData?> ScanAndPairButton(CancellationToken cancellationToken);
-        void SubscribeToButtonEvents(string serialNumber, Action<FlicButtonEventData> flicEvent);
-        void ConnectButton(string serialNumber);
-        void DisconnectOrAbortPendingConnection(string serialNumber);
-        Task<bool> UnpairButton(string serialNumber);
+        void SubscribeToButtonEvents(MAC mac, Action<FlicButtonEventData> flicEvent);
+        void ConnectButton(MAC mac);
+        void DisconnectOrAbortPendingConnection(MAC mac);
+        Task<bool> UnpairButton(MAC mac);
     }
 }

--- a/src/ids.portable.flic.button/Platforms/iOS/NativeFlicButtonManager.cs
+++ b/src/ids.portable.flic.button/Platforms/iOS/NativeFlicButtonManager.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using System.Threading;
 using IDS.Portable.Common;
 using FlicLibraryIos;
+using IDS.Core.IDS_CAN;
+using IDS.Portable.LogicalDevice;
 
 namespace IDS.Portable.Flic.Button.Platforms.iOS
 {
@@ -104,7 +106,7 @@ namespace IDS.Portable.Flic.Button.Platforms.iOS
             return await tcs.TryWaitAsync(cancellationToken);
         }
 
-        public void SubscribeToButtonEvents(string serialNumber, Action<FlicButtonEventData> flicEvent)
+        public void SubscribeToButtonEvents(MAC mac, Action<FlicButtonEventData> flicEvent)
         {
             if (!_managerReady)
                 throw new FlicButtonManagerNotReadyException();
@@ -115,14 +117,14 @@ namespace IDS.Portable.Flic.Button.Platforms.iOS
                 throw new FlicButtonManagerNullException();
 
             var buttons = manager.Buttons;
-            var button = buttons.FirstOrDefault(button => button.SerialNumber == serialNumber);
+            var button = buttons.FirstOrDefault(button => button.BluetoothAddress.ToMAC() == mac);
             if (button is null)
-                throw new FlicButtonNullException($"No flic button found with the serial number: {serialNumber}");
+                throw new FlicButtonNullException($"No flic button found with the mac: {mac}");
 
             button.Delegate = new FlicButtonCallback(flicEvent);
         }
 
-        public void ConnectButton(string serialNumber)
+        public void ConnectButton(MAC mac)
         {
             if (!_managerReady)
                 throw new FlicButtonManagerNotReadyException();
@@ -133,14 +135,14 @@ namespace IDS.Portable.Flic.Button.Platforms.iOS
                 throw new FlicButtonManagerNullException();
 
             var buttons = manager.Buttons;
-            var button = buttons.FirstOrDefault(button => button.SerialNumber == serialNumber);
+            var button = buttons.FirstOrDefault(button => button.BluetoothAddress.ToMAC() == mac);
             if (button is null)
-                throw new FlicButtonNullException($"No flic button found with the serial number: {serialNumber}");
+                throw new FlicButtonNullException($"No flic button found with the mac: {mac}");
 
             button.Connect();
         }
 
-        public void DisconnectOrAbortPendingConnection(string serialNumber)
+        public void DisconnectOrAbortPendingConnection(MAC mac)
         {
             if (!_managerReady)
                 throw new FlicButtonManagerNotReadyException();
@@ -151,14 +153,14 @@ namespace IDS.Portable.Flic.Button.Platforms.iOS
                 throw new FlicButtonManagerNullException();
 
             var buttons = manager.Buttons;
-            var button = buttons.FirstOrDefault(button => button.SerialNumber == serialNumber);
+            var button = buttons.FirstOrDefault(button => button.BluetoothAddress.ToMAC() == mac);
             if (button is null)
-                throw new FlicButtonNullException($"No flic button found with the serial number: {serialNumber}");
+                throw new FlicButtonNullException($"No flic button found with the mac: {mac}");
 
             button.Disconnect();
         }
 
-        public async Task<bool> UnpairButton(string serialNumber)
+        public async Task<bool> UnpairButton(MAC mac)
         {
             if (!_managerReady)
                 throw new FlicButtonManagerNotReadyException();
@@ -169,9 +171,9 @@ namespace IDS.Portable.Flic.Button.Platforms.iOS
                 throw new FlicButtonManagerNullException();
 
             var buttons = manager.Buttons;
-            var button = buttons.FirstOrDefault(button => button.SerialNumber == serialNumber);
+            var button = buttons.FirstOrDefault(button => button.BluetoothAddress.ToMAC() == mac);
             if (button is null)
-                throw new FlicButtonNullException($"No flic button found with the serial number: {serialNumber}");
+                throw new FlicButtonNullException($"No flic button found with the mac: {mac}");
 
             var cts = new CancellationTokenSource(UnpairFlicButtonTimeoutMs);
             var cancellationToken = cts.Token;


### PR DESCRIPTION
The serial number wasn't being saved to the realm database, and it would have been a bigger tear up to change things on that end, so I just swapped from using the serial number to identify the flic to the mac.