### PR TITLE
bugfix/CURT-311 - Not handling Flic button operation properly (Discrepency from original app)

### DIFF
--- a/src/ids.portable.flic.button/Platforms/Android/NativeFlicButtonManager.cs
+++ b/src/ids.portable.flic.button/Platforms/Android/NativeFlicButtonManager.cs
@@ -7,11 +7,15 @@ using System.Threading.Tasks;
 using System.Threading;
 using IDS.Core.IDS_CAN;
 using IDS.Portable.LogicalDevice;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace IDS.Portable.Flic.Button.Platforms.Android
 {
     internal class NativeFlicButtonManager : IFlicButtonManager
     {
+        private readonly ConcurrentDictionary<MAC, List<FlicButtonListenerCallback>> _buttonListenerCallbacks = new();
+
         public NativeFlicButtonPlatform Platform => NativeFlicButtonPlatform.Android;
 
         public Task Init()
@@ -28,13 +32,16 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
         public async Task<FlicButtonDeviceData?> ScanAndPairButton(CancellationToken cancellationToken)
         {
             var manager = Flic2Manager.Instance;
-
+            
             if (manager is null)
                 throw new FlicButtonManagerNullException();
 
             var tcs = new TaskCompletionSource<FlicButtonDeviceData?>();
 
             // One attempt is a 30 second scan.
+            foreach (var button in manager.Buttons)
+                await UnpairButton(button.BdAddr.ToMAC());
+            
             manager.StartScan(new FlicScanPairCallback(tcs));
 
             return await tcs.TryWaitAsync(cancellationToken);
@@ -52,7 +59,7 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
             if (button is null)
                 throw new FlicButtonNullException($"No flic button found with the mac: {mac}");
 
-            button.AddListener(new FlicButtonListenerCallback(flicEvent));
+            AddButtonListenerCallback(mac, button, flicEvent);
         }
 
         public void ConnectButton(MAC mac)
@@ -66,7 +73,7 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
             var button = buttons.FirstOrDefault(button => button.BdAddr.ToMAC() == mac);
             if (button is null)
                 throw new FlicButtonNullException($"No flic button found with the mac: {mac}");
-
+            
             button.Connect();
         }
 
@@ -81,6 +88,8 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
             var button = buttons.FirstOrDefault(button => button.BdAddr.ToMAC() == mac);
             if (button is null)
                 throw new FlicButtonNullException($"No flic button found with the mac: {mac}");
+
+            RemoveButtonListenerCallback(mac, button);
 
             button.DisconnectOrAbortPendingConnection();
         }
@@ -97,12 +106,35 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
             if (button is null)
                 throw new FlicButtonNullException($"No flic button found with the mac: {mac}");
 
+            RemoveButtonListenerCallback(mac, button);
+
             manager.ForgetButton(button);
 
             if (manager.Buttons.Contains(button))
                 return Task.FromResult(false);
 
             return Task.FromResult(true);
+        }
+
+        private void AddButtonListenerCallback(MAC mac, Flic2Button button, Action<FlicButtonEventData> flicEvent)
+        {
+            var buttonListenerCallback = new FlicButtonListenerCallback(flicEvent);
+
+            _buttonListenerCallbacks.TryAdd(mac, new List<FlicButtonListenerCallback>());
+            _buttonListenerCallbacks[mac].Add(buttonListenerCallback);
+
+            button.AddListener(buttonListenerCallback);
+        }
+
+        private void RemoveButtonListenerCallback(MAC mac, Flic2Button button)
+        {
+            if (_buttonListenerCallbacks.TryGetValue(mac, out var buttonListenerCallbacks) is false)
+                return;
+
+            foreach (var listenerCallback in buttonListenerCallbacks)
+                button.RemoveListener(listenerCallback);
+
+            _buttonListenerCallbacks.TryRemove(mac);
         }
     }
 }

--- a/src/ids.portable.flic.button/Platforms/Android/NativeFlicButtonManager.cs
+++ b/src/ids.portable.flic.button/Platforms/Android/NativeFlicButtonManager.cs
@@ -16,7 +16,10 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
     {
         private readonly ConcurrentDictionary<MAC, List<FlicButtonListenerCallback>> _buttonListenerCallbacks = new();
 
+        private Flic2Button? _flicButton;
+
         public NativeFlicButtonPlatform Platform => NativeFlicButtonPlatform.Android;
+        public bool IsConnected => _flicButton?.ConnectionState is Flic2Button.ConnectionStateConnectedReady;
 
         public Task Init()
         {
@@ -56,9 +59,8 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
 
             var buttons = manager.Buttons;
             var button = buttons.FirstOrDefault(button => button.BdAddr.ToMAC() == mac);
-            if (button is null)
-                throw new FlicButtonNullException($"No flic button found with the mac: {mac}");
 
+            _flicButton = button ?? throw new FlicButtonNullException($"No flic button found with the mac: {mac}");
             AddButtonListenerCallback(mac, button, flicEvent);
         }
 

--- a/src/ids.portable.flic.button/Platforms/Android/NativeFlicButtonManager.cs
+++ b/src/ids.portable.flic.button/Platforms/Android/NativeFlicButtonManager.cs
@@ -43,8 +43,11 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
 
             // One attempt is a 30 second scan.
             foreach (var button in manager.Buttons)
-                await UnpairButton(button.BdAddr.ToMAC());
-            
+            {
+                RemoveButtonListenerCallback(button.BdAddr.ToMAC(), button);
+                manager.ForgetButton(button);
+            }
+
             manager.StartScan(new FlicScanPairCallback(tcs));
 
             return await tcs.TryWaitAsync(cancellationToken);

--- a/src/ids.portable.flic.button/Platforms/Shared/FlicButtonBleDeviceDriver.cs
+++ b/src/ids.portable.flic.button/Platforms/Shared/FlicButtonBleDeviceDriver.cs
@@ -9,6 +9,8 @@ using OneControl.Direct.IdsCanAccessoryBle.FlicButton;
 
 namespace IDS.Portable.Flic.Button.Platforms.Shared
 {
+    public delegate void UpdateFlicButtonReachabilityEventHandler(FlicButtonBleDeviceDriver echoBrakeControlBle);
+
     public class FlicButtonBleDeviceDriver : CommonDisposable, IFlicButtonBleDeviceDriver
     {
         private const string LogTag = nameof(FlicButtonBleDeviceDriver);
@@ -22,6 +24,8 @@ namespace IDS.Portable.Flic.Button.Platforms.Shared
         private readonly IFlicButtonBleDeviceSource _sourceDirect;   // This needs to be a IFlicButtonBleDeviceSource so the primary source can be looked up!
 
         public bool IsConnected { get; private set; } = false;
+
+        public event UpdateFlicButtonReachabilityEventHandler? UpdateFlicButtonReachabilityEvent;
 
         public SensorConnectionFlic SensorConnection { get; }
 
@@ -64,6 +68,7 @@ namespace IDS.Portable.Flic.Button.Platforms.Shared
         private void OnFlicButtonEventReceived(FlicButtonEventData flicButtonEventData)
         {
             IsConnected = flicButtonEventData.Connected;
+            UpdateFlicButtonReachabilityEvent?.Invoke(this);
 
             var status = new LogicalDeviceFlicButtonStatus();
             if (flicButtonEventData.IsSingleClick)
@@ -138,6 +143,7 @@ namespace IDS.Portable.Flic.Button.Platforms.Shared
 
                 IsConnected = false;
                 _isStarted = false;
+                UpdateFlicButtonReachabilityEvent?.Invoke(this);
             }
         }
 

--- a/src/ids.portable.flic.button/Platforms/Shared/FlicButtonBleDeviceDriver.cs
+++ b/src/ids.portable.flic.button/Platforms/Shared/FlicButtonBleDeviceDriver.cs
@@ -6,31 +6,26 @@ using System;
 using System.Diagnostics;
 using OneControl.Devices.FlicButton;
 using OneControl.Direct.IdsCanAccessoryBle.FlicButton;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace IDS.Portable.Flic.Button.Platforms.Shared
 {
     public delegate void UpdateFlicButtonReachabilityEventHandler(FlicButtonBleDeviceDriver echoBrakeControlBle);
 
-    public class FlicButtonBleDeviceDriver : CommonDisposable, IFlicButtonBleDeviceDriver
+    public class FlicButtonBleDeviceDriver : BackgroundOperation, ICommonDisposable, IFlicButtonBleDeviceDriver
     {
         private const string LogTag = nameof(FlicButtonBleDeviceDriver);
-
         private readonly object _lock = new();
-
-        private bool _isStarted;
-
-        public ILogicalDeviceFlicButton? LogicalDevice { get; private set; }
-
         private readonly IFlicButtonBleDeviceSource _sourceDirect;   // This needs to be a IFlicButtonBleDeviceSource so the primary source can be looked up!
-
-        public bool IsConnected { get; private set; } = false;
-
-        public event UpdateFlicButtonReachabilityEventHandler? UpdateFlicButtonReachabilityEvent;
-
-        public SensorConnectionFlic SensorConnection { get; }
+        private const int SleepTimeMs = 2000;
 
         internal Guid BleDeviceId => SensorConnection.ConnectionGuid;
 
+        public ILogicalDeviceFlicButton? LogicalDevice { get; private set; }
+        public bool IsConnected { get; private set; } = false;
+        public event UpdateFlicButtonReachabilityEventHandler? UpdateFlicButtonReachabilityEvent;
+        public SensorConnectionFlic SensorConnection { get; }
         public MAC AccessoryMacAddress { get; }
 
         public FlicButtonBleDeviceDriver(IFlicButtonBleDeviceSource sourceDirect, SensorConnectionFlic sensorConnection)
@@ -102,20 +97,18 @@ namespace IDS.Portable.Flic.Button.Platforms.Shared
             return IsConnected ? LogicalDeviceReachability.Reachable : LogicalDeviceReachability.Unreachable;
         }
 
-        public void Start()
+        /// <summary>
+        /// Main background operation use Start() to start it and Stop() to stop it!
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        protected override async Task BackgroundOperationAsync(CancellationToken cancellationToken)
         {
-            lock (_lock)
+            while (!cancellationToken.IsCancellationRequested && !IsDisposed)
             {
-                if (_isStarted)
-                    return;
-
-                _isStarted = true;
-
                 try
                 {
                     // Close any open connection
-                    FlicButtonManager.Instance.DisconnectOrAbortPendingConnection(SensorConnection.AccessoryMac);
-
                     FlicButtonManager.Instance.SubscribeToButtonEvents(SensorConnection.AccessoryMac, OnFlicButtonEventReceived);
 
                     // Open Connection
@@ -125,31 +118,58 @@ namespace IDS.Portable.Flic.Button.Platforms.Shared
                 {
                     TaggedLog.Error(LogTag, $"Failed to connect to Flic Button, message: {ex.Message}");
                 }
-            }
-        }
 
-        public void Stop()
-        {
-            lock (_lock)
+                // Short delay to give the button time to connect.
+                await TaskExtension.TryDelay(SleepTimeMs, cancellationToken);
+
+                while (FlicButtonManager.Instance.IsConnected && !cancellationToken.IsCancellationRequested && !IsDisposed)
+                {
+                    await TaskExtension.TryDelay(SleepTimeMs, cancellationToken);
+                }
+            }
+
+            UpdateFlicButtonReachabilityEvent?.Invoke(this);
+
+            try
             {
-                try
-                {
-                    FlicButtonManager.Instance.DisconnectOrAbortPendingConnection(SensorConnection.AccessoryMac);
-                }
-                catch (Exception e)
-                {
-                    TaggedLog.Debug(LogTag, $"Problem disconnecting Flic Button: {e}");
-                }
-
-                IsConnected = false;
-                _isStarted = false;
-                UpdateFlicButtonReachabilityEvent?.Invoke(this);
+                FlicButtonManager.Instance.DisconnectOrAbortPendingConnection(SensorConnection.AccessoryMac);
+            }
+            catch (Exception e)
+            {
+                TaggedLog.Debug(LogTag, $"Problem disconnecting Flic Button: {e}");
             }
         }
 
-        public override void Dispose(bool disposing)
+        #region ICommonDisposable
+        private int _isDisposed;
+        public bool IsDisposed => (uint)_isDisposed > 0U;
+
+        public void TryDispose()
+        {
+            try
+            {
+                if (IsDisposed)
+                    return;
+                Dispose();
+            }
+            catch
+            {
+                /* ignored */
+            }
+        }
+
+        public void Dispose()
+        {
+            if (this.IsDisposed || Interlocked.Exchange(ref this._isDisposed, 1) != 0)
+                return;
+
+            this.Dispose(true);
+        }
+
+        public virtual void Dispose(bool disposing)
         {
             Stop();
         }
+        #endregion
     }
 }

--- a/src/ids.portable.flic.button/Platforms/Shared/FlicButtonBleDeviceSource.cs
+++ b/src/ids.portable.flic.button/Platforms/Shared/FlicButtonBleDeviceSource.cs
@@ -9,6 +9,7 @@ using IDS.Portable.LogicalDevice;
 using System.Collections.Concurrent;
 using System.Linq;
 using OneControl.Direct.IdsCanAccessoryBle.FlicButton;
+using OneControl.Devices.EchoBrakeControl;
 
 
 namespace IDS.Portable.Flic.Button.Platforms.Shared
@@ -136,8 +137,9 @@ namespace IDS.Portable.Flic.Button.Platforms.Shared
                     return false;
 
                 var flicButton = new FlicButtonBleDeviceDriver(this, sensorConnection);
+                flicButton.UpdateFlicButtonReachabilityEvent += DeviceReachabilityUpdated;
                 flicButton.LogicalDevice?.AddDeviceSource(this);
-
+                
                 var newRegistration = _registeredFlicButtons.TryAdd(bleDeviceId, flicButton);
                 if (newRegistration)
                     TaggedLog.Debug(LogTag, $"Register Flic Button {bleDeviceId}");
@@ -160,6 +162,7 @@ namespace IDS.Portable.Flic.Button.Platforms.Shared
             if (!_registeredFlicButtons.TryRemove(bleDeviceId, out var flicButton))
                 return;
 
+            flicButton.UpdateFlicButtonReachabilityEvent -= DeviceReachabilityUpdated;
             flicButton.TryDispose();  // This will also stop the brake control if it had been started
         }
 

--- a/src/ids.portable.flic.button/Platforms/Shared/FlicButtonManager.cs
+++ b/src/ids.portable.flic.button/Platforms/Shared/FlicButtonManager.cs
@@ -53,6 +53,10 @@ namespace IDS.Portable.Flic.Button.Platforms.Shared
         /// no device was paired.</returns>
         public async Task<FlicButtonDeviceData?> ScanAndPairButton(CancellationToken cancellationToken) =>
             await _nativeFlicButtonManager.ScanAndPairButton(cancellationToken);
+        
+        
+        public bool IsConnected => _nativeFlicButtonManager.IsConnected;
+
 
         /// <summary>
         /// Subscribes to a flic button's events with an Action that returns FlicButtonEventData information about the events.

--- a/src/ids.portable.flic.button/Platforms/Shared/IFlicButtonManager.cs
+++ b/src/ids.portable.flic.button/Platforms/Shared/IFlicButtonManager.cs
@@ -54,6 +54,7 @@ namespace IDS.Portable.Flic.Button.Platforms.Shared
         NativeFlicButtonPlatform Platform { get; }
 
         Task Init();
+        bool IsConnected { get; }
         Task<FlicButtonDeviceData?> ScanAndPairButton(CancellationToken cancellationToken);
         void SubscribeToButtonEvents(MAC mac, Action<FlicButtonEventData> flicEvent);
         void ConnectButton(MAC mac);

--- a/src/ids.portable.flic.button/Platforms/iOS/FlicButtonCallback.cs
+++ b/src/ids.portable.flic.button/Platforms/iOS/FlicButtonCallback.cs
@@ -82,6 +82,7 @@ namespace IDS.Portable.Flic.Button.Platforms.iOS
             _flicEventData.WasQueued = queued;
             _flicEventData.Timestamp = age;
             _flicEventData.IsDown = true;
+            _flicEventData.IsUp = false;
 
             _flicEvent.Invoke(_flicEventData);
         }
@@ -105,6 +106,7 @@ namespace IDS.Portable.Flic.Button.Platforms.iOS
             _flicEventData.Timestamp = age;
             _flicEventData.IsDown = false;
             _flicEventData.IsHold = false;
+            _flicEventData.IsUp = true;
 
             _flicEvent.Invoke(_flicEventData);
         }

--- a/src/ids.portable.flic.button/Platforms/iOS/NativeFlicButtonManager.cs
+++ b/src/ids.portable.flic.button/Platforms/iOS/NativeFlicButtonManager.cs
@@ -67,6 +67,9 @@ namespace IDS.Portable.Flic.Button.Platforms.iOS
             if (manager is null)
                 throw new FlicButtonManagerNullException();
 
+            foreach (var button in manager.Buttons)
+                manager.ForgetButton(button, (_, _) => { /* DO NOTHING */ });
+
             var tcs = new TaskCompletionSource<FlicButtonDeviceData?>();
 
             manager.ScanForButtonsWithStateChangeHandler((scannerStatus) =>


### PR DESCRIPTION
https://idselectronics.atlassian.net/browse/CURT-311

Added Flic button event listener removal that was causing multiple flic button click events to fire even when we switch to a new profile which was in turn interfering with manual override background operations. 

@tcunning  I followed how EchoBrakeControlBleDeviceSource uses UpdateEchoBrakeControlReachabilityEvent to notify about connection status changes and applied it to the Flic button but I'm not sure whether it's correct or anything else is needed. We need this for a different ticket so we can react to the flic button going offline while the user is pressing it and we are manually breaking so that we can stop the manual override in the echo controller. I performed some limited testing and it seems to work but need a confirmation from core services that the implementation is not missing something.

