### PR TITLE
bugfix/CURT-309 - iOS - Flic button is failing to pair

### DIFF
--- a/src/ids.portable.flic.button/Platforms/Android/FlicButtonListenerCallback.cs
+++ b/src/ids.portable.flic.button/Platforms/Android/FlicButtonListenerCallback.cs
@@ -1,10 +1,7 @@
 ﻿using IDS.Portable.Common;
+using IDS.Portable.Flic.Button.Platforms.Shared;
 using IO.Flic.Flic2libandroid;
 using System;
-using System.Collections.Generic;
-using System.Text;
-using IDS.Portable.Flic.Button.Platforms.Shared;
-using Java.Util.Logging;
 
 namespace IDS.Portable.Flic.Button.Platforms.Android
 {

--- a/src/ids.portable.flic.button/Platforms/Android/FlicButtonListenerCallback.cs
+++ b/src/ids.portable.flic.button/Platforms/Android/FlicButtonListenerCallback.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using IDS.Portable.Flic.Button.Platforms.Shared;
+using Java.Util.Logging;
 
 namespace IDS.Portable.Flic.Button.Platforms.Android
 {
@@ -52,6 +53,8 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
             base.OnButtonClickOrHold(button, wasQueued, lastQueued, timestamp, isClick, isHold);
             TaggedLog.Debug(LogTag, $"Button click or hold event: isClick: {isClick} isHold: {isHold}.");
 
+            UpdateButtonState(button);
+
             _flicEventData.WasQueued = wasQueued;
             _flicEventData.LastQueued = lastQueued;
             _flicEventData.Timestamp = timestamp;
@@ -66,6 +69,8 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
             base.OnButtonSingleOrDoubleClick(button, wasQueued, lastQueued, timestamp, isSingleClick, isDoubleClick);
             TaggedLog.Debug(LogTag, $"Button single or double click event: isSingleClick: {isSingleClick} isDoubleClick: {isDoubleClick}.");
 
+            UpdateButtonState(button);
+
             _flicEventData.WasQueued = wasQueued;
             _flicEventData.LastQueued = lastQueued;
             _flicEventData.Timestamp = timestamp;
@@ -79,6 +84,8 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
         {
             base.OnButtonSingleOrDoubleClickOrHold(button, wasQueued, lastQueued, timestamp, isSingleClick, isDoubleClick, isHold);
             TaggedLog.Debug(LogTag, $"Button single, double click, or hold event: isSingleClick: {isSingleClick} isDoubleClick: {isDoubleClick} isHold: {isHold}.");
+
+            UpdateButtonState(button);
 
             _flicEventData.WasQueued = wasQueued;
             _flicEventData.LastQueued = lastQueued;
@@ -95,6 +102,8 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
             base.OnButtonUpOrDown(button, wasQueued, lastQueued, timestamp, isUp, isDown);
             TaggedLog.Debug(LogTag, $"Button up or down event: isUp: {isUp} isDown: {isDown}.");
 
+            UpdateButtonState(button);
+
             _flicEventData.WasQueued = wasQueued;
             _flicEventData.LastQueued = lastQueued;
             _flicEventData.Timestamp = timestamp;
@@ -109,10 +118,22 @@ namespace IDS.Portable.Flic.Button.Platforms.Android
             base.OnBatteryLevelUpdated(button, level);
             TaggedLog.Debug(LogTag, $"Button battery level updated: level: {level.EstimatedPercentage}% .");
 
+            UpdateButtonState(button);
+
             _flicEventData.BatteryLevelPercent = level.EstimatedPercentage;
             _flicEventData.BatteryVoltage = level.Voltage;
 
             _flicEvent.Invoke(_flicEventData);
+        }
+
+        private void UpdateButtonState(Flic2Button button)
+        {
+            // For the properties below, we can't rely on specific events because we can easily miss
+            // them by not having the button listener setup, so we need to set them using the current button state.
+            //
+            _flicEventData.Connected = button.ConnectionState is Flic2Button.ConnectionStateConnectedReady;
+            _flicEventData.BatteryLevelPercent = button.LastKnownBatteryLevel.EstimatedPercentage;
+            _flicEventData.BatteryVoltage = button.LastKnownBatteryLevel.Voltage;
         }
     }
 }

--- a/src/ids.portable.flic.button/Platforms/iOS/FlicButtonCallback.cs
+++ b/src/ids.portable.flic.button/Platforms/iOS/FlicButtonCallback.cs
@@ -55,6 +55,8 @@ namespace IDS.Portable.Flic.Button.Platforms.iOS
         {
             TaggedLog.Debug(LogTag, $"ButtonDidReceiveButtonClick.");
 
+            UpdateButtonState(button);
+
             _flicEventData.WasQueued = queued;
             _flicEventData.Timestamp = age;
             _flicEventData.IsSingleClick = true;
@@ -66,6 +68,8 @@ namespace IDS.Portable.Flic.Button.Platforms.iOS
         public override void ButtonDidReceiveButtonDoubleClick(FLICButton button, bool queued, nint age)
         {
             TaggedLog.Debug(LogTag, $"ButtonDidReceiveButtonDoubleClick.");
+
+            UpdateButtonState(button);
 
             _flicEventData.WasQueued = queued;
             _flicEventData.Timestamp = age;
@@ -79,6 +83,8 @@ namespace IDS.Portable.Flic.Button.Platforms.iOS
         {
             TaggedLog.Debug(LogTag, $"ButtonDidReceiveButtonDown.");
 
+            UpdateButtonState(button);
+
             _flicEventData.WasQueued = queued;
             _flicEventData.Timestamp = age;
             _flicEventData.IsDown = true;
@@ -91,6 +97,8 @@ namespace IDS.Portable.Flic.Button.Platforms.iOS
         {
             TaggedLog.Debug(LogTag, $"ButtonDidReceiveButtonHold.");
 
+            UpdateButtonState(button);
+
             _flicEventData.WasQueued = queued;
             _flicEventData.Timestamp = age;
             _flicEventData.IsHold = true;
@@ -101,6 +109,8 @@ namespace IDS.Portable.Flic.Button.Platforms.iOS
         public override void ButtonDidReceiveButtonUp(FLICButton button, bool queued, nint age)
         {
             TaggedLog.Debug(LogTag, $"ButtonDidReceiveButtonUp.");
+
+            UpdateButtonState(button);
 
             _flicEventData.WasQueued = queued;
             _flicEventData.Timestamp = age;
@@ -124,6 +134,8 @@ namespace IDS.Portable.Flic.Button.Platforms.iOS
         {
             TaggedLog.Debug(LogTag, $"ButtonDidUpdateBatteryVoltage: {voltage}.");
 
+            UpdateButtonState(button);
+
             _flicEventData.BatteryVoltage = voltage;
 
             _flicEvent.Invoke(_flicEventData);
@@ -133,7 +145,18 @@ namespace IDS.Portable.Flic.Button.Platforms.iOS
         {
             TaggedLog.Debug(LogTag, $"ButtonDidUpdateNickname: {nickname}.");
 
+            UpdateButtonState(button);
+
             _flicEvent.Invoke(_flicEventData);
+        }
+
+        private void UpdateButtonState(FLICButton button)
+        {
+            // For the properties below, we can't rely on specific events because we can easily miss
+            // them by not having the button listener setup, so we need to set them using the current button state.
+            //
+            _flicEventData.Connected = button.State is FLICButtonState.Connected;
+            _flicEventData.BatteryVoltage = button.BatteryVoltage;
         }
     }
 }


### PR DESCRIPTION
https://idselectronics.atlassian.net/browse/CURT-309

Updated what data we send during Flic button events in case we missed some of the initial events that don't fire again unless the data changes since we rely on this data to be up to date when performing manual override or showing Flic button status.